### PR TITLE
Add JLTV vehicle and MK19 48rnd magazine prefabs

### DIFF
--- a/Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et
+++ b/Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et
@@ -1,0 +1,59 @@
+Vehicle : "{E03D5609EEA6E03D}Prefabs/Vehicles/Core/Wheeled_Truck_Base.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  WCS_Armament_VehicleCameraComponent "{66E12331DADD9F56}" {
+   m_Cameras {
+    WCS_VehicleCameraProps "{690A276A8DA0ED87}" : "{461B648F480A70F6}Prefabs/Vehicles/Core/Configs/WCS_Armaments_VehicleCameraProps_Mirror_Right.conf" {
+     m_Position PointInfo "{66593E66042B55BB}" {
+      Offset -0.8843 0.061 -3.5156
+      Angles -13.6131 -180 0
+     }
+     m_sId "BackupCam"
+    }
+    WCS_VehicleCameraProps "{690A2769EDA3B883}" : "{461B648F480A70F6}Prefabs/Vehicles/Core/Configs/WCS_Armaments_VehicleCameraProps_Mirror_Right.conf" {
+     m_Position PointInfo "{66593E66042B55BB}" {
+      PivotID "Scene_Root"
+      Offset 0.0255 1.9519 1.2
+      Angles 0 0 0
+     }
+     m_sId "HoodCam"
+    }
+   }
+  }
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   ActionContexts {
+    UserActionContext "{690A276A0083E628}" : "{4A5C71F598B94922}Prefabs/Vehicles/Core/Configs/WCS_Armaments_UserActionContext_Mirror_Right.conf" {
+     ContextName "HoodCam"
+     Position PointInfo "{66593E603D4A81E7}" {
+      Offset -0.8148 0.7462 -0.3125
+      Angles 0 -110 0
+     }
+    }
+    UserActionContext "{690A276A64330DC0}" : "{4A5C71F598B94922}Prefabs/Vehicles/Core/Configs/WCS_Armaments_UserActionContext_Mirror_Right.conf" {
+     ContextName "BackupCam"
+     Position PointInfo "{66593E603D4A81E7}" {
+      Offset -0.8088 0.6409 -0.3438
+      Angles 0 -110 0
+     }
+    }
+   }
+   additionalActions {
+    WCS_Armament_VehicleCameraAction "{690A276B5A35275E}" : "{67D39579157E8C2C}Prefabs/Vehicles/Core/Configs/WCS_Armaments_VehicleCameraAction_Mirror_Right.conf" {
+     ParentContextList {
+      "BackupCam"
+     }
+     m_sCameraId "BackupCam"
+    }
+    WCS_Armament_VehicleCameraAction "{690A276B585B3D38}" : "{67D39579157E8C2C}Prefabs/Vehicles/Core/Configs/WCS_Armaments_VehicleCameraAction_Mirror_Right.conf" {
+     ParentContextList {
+      "HoodCam"
+     }
+     UIInfo SCR_ActionUIInfo "{629D11CB1C21D168}" {
+      Name "HoodCam"
+     }
+     m_sCameraId "HoodCam"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et.meta
+++ b/Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{3A4CDF7428E32E7C}Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et
+++ b/Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et
@@ -1,0 +1,11 @@
+GenericEntity : "{928CAC2A1FB43429}Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_32rnd_Base.et" {
+ ID "CA6BE4D6BB2D1077"
+ components {
+  MagazineComponent "{CA6BE4D6B4DAFD69}" {
+   AmmoMapping + {
+    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+   }
+  }
+ }
+ coords -0.398 3.364 1.616
+}

--- a/Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et.meta
+++ b/Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{246807DD30734F3E}Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Override JLTV base to add actions for a backup and hood camera view from the driver seat and add MK-19 48-round magazine.