### PR TITLE
Add vehicle mirror/rearview cameras

### DIFF
--- a/Prefabs/Vehicles/Wheeled/BRDM2/BRDM2_base.et
+++ b/Prefabs/Vehicles/Wheeled/BRDM2/BRDM2_base.et
@@ -1,7 +1,30 @@
 Vehicle : "{543A50BF3A42AD47}Prefabs/Vehicles/Core/Wheeled_APC_Base.et" {
  ID "BBCBA43A9778AE21"
  components {
+  WCS_Armament_VehicleCameraComponent "{64C89DC0626D4F29}" {
+   m_Cameras {
+    WCS_VehicleCameraProps "{64C89DC5B285270C}" {
+     m_Position PointInfo "{64C89DC5B28526C7}" {
+      Offset -1.0126 1.7918 2.1062
+      Angles 0 -176.0977 0
+     }
+    }
+   }
+  }
   ActionsManagerComponent "{C97BE5489221AE18}" {
+   ActionContexts {
+    UserActionContext "{64C89DC2EF44FB53}" {
+     Position PointInfo "{64C89DC2EF44FB04}" {
+      Offset -0.6333 1.6602 1.6824
+     }
+    }
+    UserActionContext "{690D096E55EE7FE7}" {
+     ContextName "periscope_driver_RearView"
+     Position PointInfo "{64C89DC2EF44FB04}" {
+      Offset -0.5889 1.6602 1.7677
+     }
+    }
+   }
    additionalActions {
     WCS_Armament_VehicleCameraAction "{64C89DC4B57AF02A}" {
      ParentContextList {
@@ -20,7 +43,10 @@ Vehicle : "{543A50BF3A42AD47}Prefabs/Vehicles/Core/Wheeled_APC_Base.et" {
      }
     }
     WCS_Armament_VehicleCameraAction "{64C89DC4DC11A50C}" {
-     ParentContextList {
+     ParentContextList +{
+     }
+     UIInfo SCR_ActionUIInfo "{629D11CB1C21D168}" {
+      Name "Rearview Mirror"
      }
     }
     WCS_Armament_VehicleCameraAction "{64C89DC4DD4B2B1E}" {

--- a/Prefabs/Vehicles/Wheeled/M998/Humr_base.et
+++ b/Prefabs/Vehicles/Wheeled/M998/Humr_base.et
@@ -1,0 +1,73 @@
+Vehicle : "{1F9BB80C3EC3C891}Prefabs/Vehicles/Core/Wheeled_Car_Base.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   ActionContexts {
+    UserActionContext "{690D096198BD00E5}" {
+     ContextName "Mirror_L01"
+     Position PointInfo "{66593E603D4A81E7}" {
+      PivotID "v_door_L01"
+      Offset -0.1218 0.41 -0.0841
+      Angles 0 110 0
+     }
+     Radius 0.4
+     Omnidirectional 0
+     VisibilityAngle 30
+    }
+    UserActionContext "{690D0961985AAAFA}" {
+     ContextName "Mirror_R01"
+     Position PointInfo "{66593E603D4A81E7}" {
+      PivotID "v_door_R01"
+      Offset 0.1052 0.41 -0.0841
+      Angles 0 -110 0
+     }
+     Radius 0.4
+     Omnidirectional 0
+     VisibilityAngle 30
+    }
+   }
+   additionalActions {
+    WCS_Armament_VehicleCameraAction "{690D0961E19093D0}" {
+     ParentContextList {
+      "Mirror_L01"
+     }
+     m_sActionStateOn ""
+     m_sActionStateOff ""
+     m_bPilotOnly 0
+     m_bInteriorOnly 1
+     m_sCameraId "Mirror_L01"
+    }
+    WCS_Armament_VehicleCameraAction "{690D0961FF103910}" {
+     ParentContextList {
+      "Mirror_R01"
+     }
+     m_sActionStateOn ""
+     m_sActionStateOff ""
+     m_bPilotOnly 0
+     m_bInteriorOnly 1
+     m_sCameraId "Mirror_R01"
+    }
+   }
+  }
+  WCS_Armament_VehicleCameraComponent "{690D096131320A1D}" {
+   m_Cameras {
+    WCS_VehicleCameraProps "{690D09614C0C0F4B}" {
+     m_Position PointInfo "{66593E66042B55BB}" {
+      PivotID "v_door_L01"
+      Offset -0.1218 0.41 -0.0841
+      Angles 0 180 0
+     }
+     m_sId "Mirror_L01"
+    }
+    WCS_VehicleCameraProps "{690D09614C28380A}" {
+     m_Position PointInfo "{66593E66042B55BB}" {
+      PivotID "v_door_R01"
+      Offset 0.1052 0.41 -0.0841
+      Angles 0 180 0
+     }
+     m_sId "Mirror_R01"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/Humr_base.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/Humr_base.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{0403FB7965F89864}Prefabs/Vehicles/Wheeled/M998/Humr_base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Add camera support to wheeled vehicle prefabs: modify BRDM2_base.et to include a WCS_Armament_VehicleCameraComponent, new ActionContexts for driver/periscope rearview positions, and camera actions (including UI name "Rearview Mirror"). Add a new M998/Humr_base.et prefab with mirror ActionContexts ("Mirror_L01", "Mirror_R01"), camera actions referencing those contexts, a WCS_Armament_VehicleCameraComponent with mirror camera props, and the corresponding Humr_base.et.meta with platform configurations.