### PR TITLE
Add universal inventory storage to JLTV base

### DIFF
--- a/Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et
+++ b/Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et
@@ -1,6 +1,60 @@
 Vehicle : "{E03D5609EEA6E03D}Prefabs/Vehicles/Core/Wheeled_Truck_Base.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_UniversalInventoryStorageComponent "{5C946CE5223089AE}" {
+   MultiSlots {
+    MultiSlotConfiguration "{69351B36A07A262E}" {
+     SlotTemplate InventoryStorageSlot bandaid {
+      Prefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+     }
+     NumSlots 5
+    }
+    MultiSlotConfiguration "{69351B36A01F2FF0}" {
+     SlotTemplate InventoryStorageSlot Tourniquets {
+      Prefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+     }
+     NumSlots 5
+    }
+    MultiSlotConfiguration "{69351B36A03EEABC}" {
+     SlotTemplate InventoryStorageSlot Morphine {
+      Prefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+     }
+     NumSlots 5
+    }
+    MultiSlotConfiguration "{69351B36A1F6C176}" {
+     SlotTemplate InventoryStorageSlot M16ammo {
+      Prefab "{D8F2CA92583B23D3}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_30rnd_M855_M856_Last_5Tracer.et"
+     }
+     NumSlots 16
+    }
+    MultiSlotConfiguration "{69351B36A18D291C}" {
+     SlotTemplate InventoryStorageSlot Grenades {
+      Prefab "{E8F00BF730225B00}Prefabs/Weapons/Grenades/Grenade_M67.et"
+     }
+     NumSlots 8
+    }
+    MultiSlotConfiguration "{69351B36A1AE20B9}" {
+     SlotTemplate InventoryStorageSlot SmokeGrenades {
+      Prefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+     }
+     NumSlots 8
+    }
+    MultiSlotConfiguration "{69351B36A145BB84}" {
+     SlotTemplate InventoryStorageSlot ugl {
+      Prefab "{5375FA7CB1F68573}Prefabs/Weapons/Ammo/Ammo_Grenade_HE_M406.et"
+     }
+     NumSlots 8
+    }
+    MultiSlotConfiguration "{69351B36A10B8D09}" {
+     SlotTemplate InventoryStorageSlot ugl_flare {
+      Prefab "{98DB57ECEDC81CC2}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_M583A1_White.et"
+     }
+     NumSlots 8
+    }
+    MultiSlotConfiguration "{69351B36BEDAC864}" {
+    }
+   }
+  }
   WCS_Armament_VehicleCameraComponent "{66E12331DADD9F56}" {
    m_Cameras {
     WCS_VehicleCameraProps "{690A276A8DA0ED87}" : "{461B648F480A70F6}Prefabs/Vehicles/Core/Configs/WCS_Armaments_VehicleCameraProps_Mirror_Right.conf" {


### PR DESCRIPTION
Add SCR_UniversalInventoryStorageComponent to Prefabs/Vehicles/Wheeled/JLTV/JLTV_Base.et. Defines multiple MultiSlotConfiguration entries providing dedicated slots for field dressings (5), tourniquets (5), morphine injections (5), M16/STANAG ammo (16), frag grenades (8), smoke grenades (8), 40mm HE rounds (8) and 40mm flare rounds (8). This enables the JLTV to carry predefined medical supplies and assorted ammunition for vehicle crew loadouts.